### PR TITLE
add minimal diagnostics to purge_removed_accounts

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -792,15 +792,23 @@ namespace :mastodon do
 
         begin
           code = Request.new(:head, account.uri).perform(&:code)
-        rescue StandardError
+        rescue StandardError => e
           # This could happen due to network timeout, DNS timeout, wrong SSL cert, etc,
           # which should probably not lead to perceiving the account as deleted, so
           # just skip till next time
+          progress_bar.pause
+          progress_bar.clear
+          print "ignored: #{account.acct}, #{e}\n"
+          progress_bar.resume
           next
         end
 
         if [404, 410].include?(code)
           if options[:force]
+            progress_bar.pause
+            progress_bar.clear
+            print "deleting: #{account.acct}, #{account.uri} no longer exists.\n"
+            progress_bar.resume
             SuspendAccountService.new.call(account)
             account.destroy
           else


### PR DESCRIPTION
Informational messages for mastodon:maintenance:purge_removed_accounts rake task in --force mode. Not suitable for logging thanks to the progress bar, but it's possible to record the output using script(1)